### PR TITLE
fix(plugins): fix how we send plugin name so it can include slashes

### DIFF
--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/Daemon.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/Daemon.java
@@ -1329,6 +1329,16 @@ public class Daemon {
     };
   }
 
+  public static Supplier<Plugin> getPluginByQueryParam(
+      String deploymentName, String pluginName, boolean validate) {
+    return () -> {
+      Object rawPlugin =
+          ResponseUnwrapper.get(
+              getService().getPluginByQueryParam(deploymentName, pluginName, validate));
+      return getObjectMapper().convertValue(rawPlugin, Plugin.class);
+    };
+  }
+
   public static Supplier<Void> addPlugin(String deploymentName, boolean validate, Plugin plugin) {
     return () -> {
       ResponseUnwrapper.get(getService().addPlugin(deploymentName, validate, plugin));

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/DaemonService.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/DaemonService.java
@@ -902,6 +902,12 @@ public interface DaemonService {
       @Path("pluginName") String pluginName,
       @Query("validate") boolean validate);
 
+  @GET("/v1/config/deployments/{deploymentName}/plugins/byQuery")
+  DaemonTask<Halconfig, Object> getPluginByQueryParam(
+      @Path("deploymentName") String deploymentName,
+      @Query("pluginName") String pluginName,
+      @Query("validate") boolean validate);
+
   @PUT("/v1/config/deployments/{deploymentName}/plugins/{pluginName}/")
   DaemonTask<Halconfig, Void> setPlugin(
       @Path("deploymentName") String deploymentName,

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/PluginsController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/PluginsController.java
@@ -63,6 +63,19 @@ public class PluginsController {
         .execute(validationSettings);
   }
 
+  @RequestMapping(value = "/byQuery", method = RequestMethod.GET)
+  DaemonTask<Halconfig, Plugin> getPluginByQuery(
+      @PathVariable String deploymentName,
+      @RequestParam String pluginName,
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<Plugin>builder()
+        .getter(() -> pluginService.getPlugin(deploymentName, pluginName))
+        .validator(() -> pluginService.validatePlugin(deploymentName, pluginName))
+        .description("Get the " + pluginName + " plugin")
+        .build()
+        .execute(validationSettings);
+  }
+
   @RequestMapping(value = "/{pluginName:.+}", method = RequestMethod.PUT)
   DaemonTask<Halconfig, Void> setPlugin(
       @PathVariable String deploymentName,


### PR DESCRIPTION
when using the halyard cli to edit or delete a plugin, we must pass the plugin name. If the name contains slashes, then it causes issues when sending the url encoded string as part of the path. To get around this, we change how halyard sends the plugin name to halyard as part of the query param.

stack overflow discussion: https://stackoverflow.com/questions/13482020/encoded-slash-2f-with-spring-requestmapping-path-param-gives-http-400
request param info: https://www.baeldung.com/spring-request-param 