### PR TITLE
chore(versions): Return version list without using daemon tasks

### DIFF
--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/VersionsController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/VersionsController.java
@@ -39,6 +39,11 @@ public class VersionsController {
     return DaemonTaskHandler.submitTask(builder::build, "Get released versions");
   }
 
+  @RequestMapping(value = "/", method = RequestMethod.GET, params = "daemon=false")
+  Versions getAllNoDaemon() {
+    return versionsService.getVersions();
+  }
+
   @RequestMapping(value = "/latest/", method = RequestMethod.GET)
   DaemonTask<Halconfig, String> latest() {
     DaemonResponse.StaticRequestBuilder<String> builder =

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/VersionsController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/VersionsController.java
@@ -73,4 +73,9 @@ public class VersionsController {
             () -> versionsService.getBillOfMaterials(version));
     return DaemonTaskHandler.submitTask(builder::build, "Get BOM for " + version);
   }
+
+  @RequestMapping(value = "/bom", method = RequestMethod.GET, params = "daemon=false")
+  BillOfMaterials bomV2NoDaemon(@RequestParam(value = "version") String version) {
+    return versionsService.getBillOfMaterials(version);
+  }
 }


### PR DESCRIPTION
Using the `bom` endpoint to determine if a specific version exists has the problem that if the request fails, it's really hard to determine if the exception occurred because the requested version truly doesn't exist, or if the request failed because of network connectivity or other problem. Internally the code just tries to read a file from a GCS bucket, and Google SDK just throws a generic IOException if the file doesn't exist.
If instead we use the endpoint for listing all versions, we can easily know in operator code if a version truly doesn't exist vs network problems requesting the version list.