### PR TITLE
fix(canary): Fix Google Canary Validator.

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Validator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Validator.java
@@ -34,7 +34,7 @@ public abstract class Validator<T extends Node> {
           + ". Make sure that user can read the requested file.";
 
   @Autowired protected SecretSessionManager secretSessionManager;
-  @Autowired private FileService fileService;
+  @Autowired protected FileService fileService;
 
   public abstract void validate(ConfigProblemSetBuilder p, T n);
 

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/canary/CanaryValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/canary/CanaryValidator.java
@@ -72,9 +72,8 @@ public class CanaryValidator extends Validator<Canary> {
         GoogleCanaryServiceIntegration googleCanaryServiceIntegration =
             (GoogleCanaryServiceIntegration) s;
 
-        new GoogleCanaryValidator(secretSessionManager)
+        new GoogleCanaryValidator(secretSessionManager, fileService, registry)
             .setHalyardVersion(halyardVersion)
-            .setRegistry(registry)
             .setTaskScheduler(taskScheduler)
             .validate(p, googleCanaryServiceIntegration);
 

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/canary/google/GoogleCanaryAccountValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/canary/google/GoogleCanaryAccountValidator.java
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.front50.model.GcsStorageService;
 import com.netflix.spinnaker.front50.model.StorageService;
 import com.netflix.spinnaker.halyard.config.model.v1.canary.google.GoogleCanaryAccount;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
+import com.netflix.spinnaker.halyard.config.services.v1.FileService;
 import com.netflix.spinnaker.halyard.config.validate.v1.canary.CanaryAccountValidator;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
@@ -32,9 +33,11 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.scheduling.TaskScheduler;
+import org.springframework.stereotype.Component;
 
 @Data
 @EqualsAndHashCode(callSuper = false)
+@Component
 public class GoogleCanaryAccountValidator extends CanaryAccountValidator<GoogleCanaryAccount> {
 
   private String halyardVersion;
@@ -50,8 +53,11 @@ public class GoogleCanaryAccountValidator extends CanaryAccountValidator<GoogleC
   private int jitterMultiplier = 1000;
   private int maxRetries = 10;
 
-  GoogleCanaryAccountValidator(SecretSessionManager secretSessionManager) {
+  GoogleCanaryAccountValidator(
+      SecretSessionManager secretSessionManager, FileService fileService, Registry registry) {
     this.secretSessionManager = secretSessionManager;
+    this.fileService = fileService;
+    this.registry = registry;
   }
 
   @Override

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/canary/google/GoogleCanaryValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/canary/google/GoogleCanaryValidator.java
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.halyard.config.model.v1.canary.google.GoogleCanaryA
 import com.netflix.spinnaker.halyard.config.model.v1.canary.google.GoogleCanaryServiceIntegration;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Validator;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
+import com.netflix.spinnaker.halyard.config.services.v1.FileService;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
 import com.netflix.spinnaker.halyard.core.secrets.v1.SecretSessionManager;
 import java.util.List;
@@ -38,16 +39,18 @@ public class GoogleCanaryValidator extends Validator<GoogleCanaryServiceIntegrat
 
   @Setter TaskScheduler taskScheduler;
 
-  public GoogleCanaryValidator(SecretSessionManager secretSessionManager) {
+  public GoogleCanaryValidator(
+      SecretSessionManager secretSessionManager, FileService fileService, Registry registry) {
     this.secretSessionManager = secretSessionManager;
+    this.fileService = fileService;
+    this.registry = registry;
   }
 
   @Override
   public void validate(ConfigProblemSetBuilder p, GoogleCanaryServiceIntegration n) {
     GoogleCanaryAccountValidator googleCanaryAccountValidator =
-        new GoogleCanaryAccountValidator(secretSessionManager)
+        new GoogleCanaryAccountValidator(secretSessionManager, fileService, registry)
             .setHalyardVersion(halyardVersion)
-            .setRegistry(registry)
             .setTaskScheduler(taskScheduler);
 
     if (n.isGcsEnabled()) {


### PR DESCRIPTION
Since `GoogleCanaryValidator` is getting instantiated manually. it needs some Spring Beans to work because those are used to perform several validations.


This PR adds those Spring Beans to get it worked.