### PR TITLE
feat(sidecars): better sidecar support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,10 +50,6 @@ subprojects {
 
   dependencies {
     implementation platform("io.spinnaker.kork:kork-bom:$korkVersion")
-
-    // use 4.7.2 to provide access to Container::startupProbe
-    api(enforcedPlatform("io.fabric8:kubernetes-client:4.7.2"))
-
     annotationProcessor platform("io.spinnaker.kork:kork-bom:$korkVersion")
     annotationProcessor "org.projectlombok:lombok"
     testAnnotationProcessor platform("io.spinnaker.kork:kork-bom:$korkVersion")

--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,9 @@ subprojects {
   dependencies {
     implementation platform("io.spinnaker.kork:kork-bom:$korkVersion")
 
+    // use 4.7.2 to provide access to Container::startupProbe
+    api(enforcedPlatform("io.fabric8:kubernetes-client:4.7.2"))
+
     annotationProcessor platform("io.spinnaker.kork:kork-bom:$korkVersion")
     annotationProcessor "org.projectlombok:lombok"
     testAnnotationProcessor platform("io.spinnaker.kork:kork-bom:$korkVersion")

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/SidecarConfig.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/SidecarConfig.java
@@ -18,10 +18,7 @@
 
 package com.netflix.spinnaker.halyard.config.model.v1.node;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import lombok.Data;
 
 @Data
@@ -34,6 +31,10 @@ public class SidecarConfig {
   List<String> command = new ArrayList<>();
   List<ConfigMapVolumeMount> configMapVolumeMounts = new ArrayList<>();
   List<SecretVolumeMount> secretVolumeMounts = new ArrayList<>();
+  Resources resources;
+  LivenessProbe livenessProbe;
+  ReadinessProbe readinessProbe;
+  StartupProbe startupProbe;
   String mountPath;
   SecurityContext securityContext;
 
@@ -52,5 +53,44 @@ public class SidecarConfig {
   public static class SecretVolumeMount {
     String secretName;
     String mountPath;
+  }
+
+  @Data
+  public static class Resources {
+    Map<String, String> requests = new HashMap<>();
+    Map<String, String> limits = new HashMap<>();
+  }
+
+  @Data
+  public static class LivenessProbe {
+    HttpProbe httpProbe;
+    HttpGet httpGet;
+  }
+
+  @Data
+  public static class ReadinessProbe {
+    HttpProbe httpProbe;
+    HttpGet httpGet;
+    Integer successThreshold;
+  }
+
+  @Data
+  public static class StartupProbe {
+    HttpProbe httpProbe;
+    HttpGet httpGet;
+  }
+
+  @Data
+  static class HttpGet {
+    String path;
+    Integer port;
+  }
+
+  @Data
+  static class HttpProbe {
+    Integer initialDelaySeconds;
+    Integer periodSeconds;
+    Integer timeoutSeconds;
+    Integer failureThreshold;
   }
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/SidecarConfig.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/SidecarConfig.java
@@ -64,26 +64,16 @@ public class SidecarConfig {
   @Data
   public static class LivenessProbe {
     HttpProbe httpProbe;
-    HttpGet httpGet;
   }
 
   @Data
   public static class ReadinessProbe {
     HttpProbe httpProbe;
-    HttpGet httpGet;
   }
 
   @Data
   public static class StartupProbe {
     HttpProbe httpProbe;
-    HttpGet httpGet;
-  }
-
-  @Data
-  public static class HttpGet {
-    Integer port;
-    String path;
-    String scheme;
   }
 
   @Data
@@ -93,5 +83,13 @@ public class SidecarConfig {
     Integer timeoutSeconds;
     Integer successThreshold;
     Integer failureThreshold;
+    HttpGet httpGet;
+  }
+
+  @Data
+  public static class HttpGet {
+    Integer port;
+    String path;
+    String scheme;
   }
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/SidecarConfig.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/SidecarConfig.java
@@ -71,7 +71,6 @@ public class SidecarConfig {
   public static class ReadinessProbe {
     HttpProbe httpProbe;
     HttpGet httpGet;
-    Integer successThreshold;
   }
 
   @Data
@@ -81,16 +80,18 @@ public class SidecarConfig {
   }
 
   @Data
-  static class HttpGet {
-    String path;
+  public static class HttpGet {
     Integer port;
+    String path;
+    String scheme;
   }
 
   @Data
-  static class HttpProbe {
+  public static class HttpProbe {
     Integer initialDelaySeconds;
     Integer periodSeconds;
     Integer timeoutSeconds;
+    Integer successThreshold;
     Integer failureThreshold;
   }
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/SidecarConfig.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/SidecarConfig.java
@@ -32,9 +32,9 @@ public class SidecarConfig {
   List<ConfigMapVolumeMount> configMapVolumeMounts = new ArrayList<>();
   List<SecretVolumeMount> secretVolumeMounts = new ArrayList<>();
   Resources resources;
-  HttpProbe livenessProbe;
-  HttpProbe readinessProbe;
-  HttpProbe startupProbe;
+  Probe livenessProbe;
+  Probe readinessProbe;
+  Probe startupProbe;
   String mountPath;
   SecurityContext securityContext;
 
@@ -62,13 +62,20 @@ public class SidecarConfig {
   }
 
   @Data
-  public static class HttpProbe {
+  public static class Probe {
     Integer initialDelaySeconds;
     Integer periodSeconds;
     Integer timeoutSeconds;
     Integer successThreshold;
     Integer failureThreshold;
     HttpGet httpGet;
+    TcpSocket tcpSocket;
+    Exec exec;
+  }
+
+  @Data
+  public static class TcpSocket {
+    Integer port;
   }
 
   @Data
@@ -77,6 +84,11 @@ public class SidecarConfig {
     String path;
     String scheme;
     List<HttpHeaders> httpHeaders = new ArrayList<>();
+  }
+
+  @Data
+  public static class Exec {
+    List<String> command = new ArrayList<>();
   }
 
   @Data

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/SidecarConfig.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/SidecarConfig.java
@@ -32,9 +32,9 @@ public class SidecarConfig {
   List<ConfigMapVolumeMount> configMapVolumeMounts = new ArrayList<>();
   List<SecretVolumeMount> secretVolumeMounts = new ArrayList<>();
   Resources resources;
-  LivenessProbe livenessProbe;
-  ReadinessProbe readinessProbe;
-  StartupProbe startupProbe;
+  HttpProbe livenessProbe;
+  HttpProbe readinessProbe;
+  HttpProbe startupProbe;
   String mountPath;
   SecurityContext securityContext;
 
@@ -59,21 +59,6 @@ public class SidecarConfig {
   public static class Resources {
     Map<String, String> requests = new HashMap<>();
     Map<String, String> limits = new HashMap<>();
-  }
-
-  @Data
-  public static class LivenessProbe {
-    HttpProbe httpProbe;
-  }
-
-  @Data
-  public static class ReadinessProbe {
-    HttpProbe httpProbe;
-  }
-
-  @Data
-  public static class StartupProbe {
-    HttpProbe httpProbe;
   }
 
   @Data

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/SidecarConfig.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/SidecarConfig.java
@@ -76,5 +76,12 @@ public class SidecarConfig {
     Integer port;
     String path;
     String scheme;
+    List<HttpHeaders> httpHeaders = new ArrayList<>();
+  }
+
+  @Data
+  public static class HttpHeaders {
+    String name;
+    String value;
   }
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -381,12 +381,14 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T>, Kubernete
     TemplatedResource probe = new JinjaJarResource("/kubernetes/manifests/httpProbe.yml");
     probe.addBinding("port", httpProbe.getHttpGet().getPort());
     probe.addBinding("path", httpProbe.getHttpGet().getPath());
-    probe.addBinding("scheme", httpProbe.getHttpGet().getScheme().toUpperCase());
     probe.addBinding("initialDelaySeconds", httpProbe.getInitialDelaySeconds());
     probe.addBinding("periodSeconds", httpProbe.getPeriodSeconds());
     probe.addBinding("timeoutSeconds", httpProbe.getTimeoutSeconds());
     probe.addBinding("failureThreshold", httpProbe.getFailureThreshold());
     probe.addBinding("successThreshold", httpProbe.getSuccessThreshold());
+    if (httpProbe.getHttpGet().getScheme() != null) {
+      probe.addBinding("scheme", httpProbe.getHttpGet().getScheme().toUpperCase());
+    }
     return probe;
   }
 

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -345,62 +345,28 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T>, Kubernete
       container.addBinding("resources", null);
     }
 
-    TemplatedResource livenessProbe = new JinjaJarResource("/kubernetes/manifests/httpProbe.yml");
-    if (config.getLivenessProbe() != null) {
-      livenessProbe.addBinding("port", config.getLivenessProbe().getHttpGet().getPort());
-      livenessProbe.addBinding("path", config.getLivenessProbe().getHttpGet().getPath());
-      livenessProbe.addBinding("scheme", config.getLivenessProbe().getHttpGet().getScheme());
-      livenessProbe.addBinding(
-          "initialDelaySeconds", config.getLivenessProbe().getHttpProbe().getInitialDelaySeconds());
-      livenessProbe.addBinding(
-          "periodSeconds", config.getLivenessProbe().getHttpProbe().getPeriodSeconds());
-      livenessProbe.addBinding(
-          "timeoutSeconds", config.getLivenessProbe().getHttpProbe().getTimeoutSeconds());
-      livenessProbe.addBinding(
-          "successThreshold", config.getLivenessProbe().getHttpProbe().getSuccessThreshold());
-      livenessProbe.addBinding(
-          "failureThreshold", config.getLivenessProbe().getHttpProbe().getFailureThreshold());
-      container.addBinding("livenessProbe", livenessProbe.toString());
-    } else {
-      container.addBinding("livenessProbe", null);
-    }
-
-    TemplatedResource readinessProbe = new JinjaJarResource("/kubernetes/manifests/httpProbe.yml");
     if (config.getReadinessProbe() != null) {
-      readinessProbe.addBinding("port", config.getReadinessProbe().getHttpGet().getPort());
-      readinessProbe.addBinding("path", config.getReadinessProbe().getHttpGet().getPath());
-      readinessProbe.addBinding("scheme", config.getReadinessProbe().getHttpGet().getScheme());
-      readinessProbe.addBinding(
-          "initialDelaySeconds",
-          config.getReadinessProbe().getHttpProbe().getInitialDelaySeconds());
-      readinessProbe.addBinding(
-          "periodSeconds", config.getReadinessProbe().getHttpProbe().getPeriodSeconds());
-      readinessProbe.addBinding(
-          "timeoutSeconds", config.getReadinessProbe().getHttpProbe().getTimeoutSeconds());
-      readinessProbe.addBinding(
-          "failureThreshold", config.getReadinessProbe().getHttpProbe().getFailureThreshold());
-      readinessProbe.addBinding(
-          "successThreshold", config.getReadinessProbe().getHttpProbe().getSuccessThreshold());
+      TemplatedResource readinessProbe =
+          getSidecarProbe(
+              config.getReadinessProbe().getHttpProbe(), config.getReadinessProbe().getHttpGet());
       container.addBinding("readinessProbe", readinessProbe.toString());
     } else {
       container.addBinding("readinessProbe", null);
     }
 
-    TemplatedResource startupProbe = new JinjaJarResource("/kubernetes/manifests/httpProbe.yml");
+    if (config.getLivenessProbe() != null) {
+      TemplatedResource livenessProbe =
+          getSidecarProbe(
+              config.getLivenessProbe().getHttpProbe(), config.getLivenessProbe().getHttpGet());
+      container.addBinding("livenessProbe", livenessProbe.toString());
+    } else {
+      container.addBinding("livenessProbe", null);
+    }
+
     if (config.getStartupProbe() != null) {
-      startupProbe.addBinding("port", config.getStartupProbe().getHttpGet().getPort());
-      startupProbe.addBinding("path", config.getStartupProbe().getHttpGet().getPath());
-      startupProbe.addBinding("scheme", config.getStartupProbe().getHttpGet().getScheme());
-      startupProbe.addBinding(
-          "initialDelaySeconds", config.getStartupProbe().getHttpProbe().getInitialDelaySeconds());
-      startupProbe.addBinding(
-          "periodSeconds", config.getStartupProbe().getHttpProbe().getPeriodSeconds());
-      startupProbe.addBinding(
-          "timeoutSeconds", config.getStartupProbe().getHttpProbe().getTimeoutSeconds());
-      startupProbe.addBinding(
-          "failureThreshold", config.getStartupProbe().getHttpProbe().getFailureThreshold());
-      startupProbe.addBinding(
-          "successThreshold", config.getStartupProbe().getHttpProbe().getSuccessThreshold());
+      TemplatedResource startupProbe =
+          getSidecarProbe(
+              config.getStartupProbe().getHttpProbe(), config.getStartupProbe().getHttpGet());
       container.addBinding("startupProbe", startupProbe.toString());
     } else {
       container.addBinding("startupProbe", null);
@@ -415,6 +381,20 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T>, Kubernete
     container.addBinding("env", config.getEnv());
 
     return container.toString();
+  }
+
+  default TemplatedResource getSidecarProbe(
+      SidecarConfig.HttpProbe httpProbe, SidecarConfig.HttpGet httpGet) {
+    TemplatedResource probe = new JinjaJarResource("/kubernetes/manifests/httpProbe.yml");
+    probe.addBinding("port", httpGet.getPort());
+    probe.addBinding("path", httpGet.getPath());
+    probe.addBinding("scheme", httpGet.getScheme());
+    probe.addBinding("initialDelaySeconds", httpProbe.getInitialDelaySeconds());
+    probe.addBinding("periodSeconds", httpProbe.getPeriodSeconds());
+    probe.addBinding("timeoutSeconds", httpProbe.getTimeoutSeconds());
+    probe.addBinding("failureThreshold", httpProbe.getFailureThreshold());
+    probe.addBinding("successThreshold", httpProbe.getSuccessThreshold());
+    return probe;
   }
 
   default String buildContainer(

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -336,16 +336,27 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T>, Kubernete
       container.addBinding("port", null);
     }
 
+    TemplatedResource resources = new JinjaJarResource("/kubernetes/manifests/resources.yml");
+    SidecarConfig.Resources configResources = config.getResources();
+    if (configResources != null) {
+      if (configResources.getRequests() != null) {
+        resources.addBinding("requests", configResources.getRequests().toString());
+      }
+      if (configResources.getLimits() != null) {
+        resources.addBinding("limits", configResources.getLimits().toString());
+      }
+    }
+
     container.addBinding("name", config.getName());
     container.addBinding("imageId", config.getDockerImage());
     container.addBinding("command", config.getCommand());
     container.addBinding("args", config.getArgs());
     container.addBinding("volumeMounts", volumeMounts);
-    container.addBinding("readinessProbe", null);
-    container.addBinding("livenessProbe", null);
+    container.addBinding("readinessProbe", config.getReadinessProbe());
+    container.addBinding("livenessProbe", config.getLivenessProbe());
     container.addBinding("lifecycle", null);
     container.addBinding("env", config.getEnv());
-    container.addBinding("resources", null);
+    container.addBinding("resources", resources);
 
     return container.toString();
   }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -460,6 +460,9 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T>, Kubernete
     TemplatedResource readinessProbe = getProbe(settings, null);
     container.addBinding("readinessProbe", readinessProbe.toString());
 
+    TemplatedResource startupProbe = getProbe(settings, null);
+    container.addBinding("startupProbe", startupProbe.toString());
+
     DeploymentEnvironment.LivenessProbeConfig livenessProbeConfig =
         deploymentEnvironment.getLivenessProbeConfig();
     if (livenessProbeConfig != null

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -388,7 +388,7 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T>, Kubernete
     TemplatedResource probe = new JinjaJarResource("/kubernetes/manifests/httpProbe.yml");
     probe.addBinding("port", httpGet.getPort());
     probe.addBinding("path", httpGet.getPath());
-    probe.addBinding("scheme", httpGet.getScheme());
+    probe.addBinding("scheme", httpGet.getScheme().toUpperCase());
     probe.addBinding("initialDelaySeconds", httpProbe.getInitialDelaySeconds());
     probe.addBinding("periodSeconds", httpProbe.getPeriodSeconds());
     probe.addBinding("timeoutSeconds", httpProbe.getTimeoutSeconds());

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -346,27 +346,21 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T>, Kubernete
     }
 
     if (config.getReadinessProbe() != null) {
-      TemplatedResource readinessProbe =
-          getSidecarProbe(
-              config.getReadinessProbe().getHttpProbe(), config.getReadinessProbe().getHttpGet());
+      TemplatedResource readinessProbe = getSidecarProbe(config.getReadinessProbe().getHttpProbe());
       container.addBinding("readinessProbe", readinessProbe.toString());
     } else {
       container.addBinding("readinessProbe", null);
     }
 
     if (config.getLivenessProbe() != null) {
-      TemplatedResource livenessProbe =
-          getSidecarProbe(
-              config.getLivenessProbe().getHttpProbe(), config.getLivenessProbe().getHttpGet());
+      TemplatedResource livenessProbe = getSidecarProbe(config.getLivenessProbe().getHttpProbe());
       container.addBinding("livenessProbe", livenessProbe.toString());
     } else {
       container.addBinding("livenessProbe", null);
     }
 
     if (config.getStartupProbe() != null) {
-      TemplatedResource startupProbe =
-          getSidecarProbe(
-              config.getStartupProbe().getHttpProbe(), config.getStartupProbe().getHttpGet());
+      TemplatedResource startupProbe = getSidecarProbe(config.getStartupProbe().getHttpProbe());
       container.addBinding("startupProbe", startupProbe.toString());
     } else {
       container.addBinding("startupProbe", null);
@@ -383,12 +377,11 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T>, Kubernete
     return container.toString();
   }
 
-  default TemplatedResource getSidecarProbe(
-      SidecarConfig.HttpProbe httpProbe, SidecarConfig.HttpGet httpGet) {
+  default TemplatedResource getSidecarProbe(SidecarConfig.HttpProbe httpProbe) {
     TemplatedResource probe = new JinjaJarResource("/kubernetes/manifests/httpProbe.yml");
-    probe.addBinding("port", httpGet.getPort());
-    probe.addBinding("path", httpGet.getPath());
-    probe.addBinding("scheme", httpGet.getScheme().toUpperCase());
+    probe.addBinding("port", httpProbe.getHttpGet().getPort());
+    probe.addBinding("path", httpProbe.getHttpGet().getPath());
+    probe.addBinding("scheme", httpProbe.getHttpGet().getScheme().toUpperCase());
     probe.addBinding("initialDelaySeconds", httpProbe.getInitialDelaySeconds());
     probe.addBinding("periodSeconds", httpProbe.getPeriodSeconds());
     probe.addBinding("timeoutSeconds", httpProbe.getTimeoutSeconds());

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -386,6 +386,7 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T>, Kubernete
     probe.addBinding("timeoutSeconds", httpProbe.getTimeoutSeconds());
     probe.addBinding("failureThreshold", httpProbe.getFailureThreshold());
     probe.addBinding("successThreshold", httpProbe.getSuccessThreshold());
+    probe.addBinding("httpHeaders", httpProbe.getHttpGet().getHttpHeaders());
     if (httpProbe.getHttpGet().getScheme() != null) {
       probe.addBinding("scheme", httpProbe.getHttpGet().getScheme().toUpperCase());
     }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -377,20 +377,31 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T>, Kubernete
     return container.toString();
   }
 
-  default TemplatedResource getSidecarProbe(SidecarConfig.HttpProbe httpProbe) {
-    TemplatedResource probe = new JinjaJarResource("/kubernetes/manifests/httpProbe.yml");
-    probe.addBinding("port", httpProbe.getHttpGet().getPort());
-    probe.addBinding("path", httpProbe.getHttpGet().getPath());
-    probe.addBinding("initialDelaySeconds", httpProbe.getInitialDelaySeconds());
-    probe.addBinding("periodSeconds", httpProbe.getPeriodSeconds());
-    probe.addBinding("timeoutSeconds", httpProbe.getTimeoutSeconds());
-    probe.addBinding("failureThreshold", httpProbe.getFailureThreshold());
-    probe.addBinding("successThreshold", httpProbe.getSuccessThreshold());
-    probe.addBinding("httpHeaders", httpProbe.getHttpGet().getHttpHeaders());
-    if (httpProbe.getHttpGet().getScheme() != null) {
-      probe.addBinding("scheme", httpProbe.getHttpGet().getScheme().toUpperCase());
+  default TemplatedResource getSidecarProbe(SidecarConfig.Probe probe) {
+    TemplatedResource tr;
+    if (probe.getHttpGet() != null) {
+      tr = new JinjaJarResource("/kubernetes/manifests/httpProbe.yml");
+      tr.addBinding("port", probe.getHttpGet().getPort());
+      tr.addBinding("path", probe.getHttpGet().getPath());
+      tr.addBinding("httpHeaders", probe.getHttpGet().getHttpHeaders());
+      if (probe.getHttpGet().getScheme() != null) {
+        tr.addBinding("scheme", probe.getHttpGet().getScheme().toUpperCase());
+      }
+    } else if (probe.getTcpSocket() != null) {
+      tr = new JinjaJarResource("/kubernetes/manifests/tcpSocketProbe.yml");
+      tr.addBinding("port", probe.getTcpSocket().getPort());
+    } else {
+      tr = new JinjaJarResource("/kubernetes/manifests/execProbe.yml");
+      tr.addBinding("command", probe.getExec().getCommand());
     }
-    return probe;
+
+    tr.addBinding("initialDelaySeconds", probe.getInitialDelaySeconds());
+    tr.addBinding("periodSeconds", probe.getPeriodSeconds());
+    tr.addBinding("timeoutSeconds", probe.getTimeoutSeconds());
+    tr.addBinding("failureThreshold", probe.getFailureThreshold());
+    tr.addBinding("successThreshold", probe.getSuccessThreshold());
+
+    return tr;
   }
 
   default String buildContainer(

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -346,21 +346,21 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T>, Kubernete
     }
 
     if (config.getReadinessProbe() != null) {
-      TemplatedResource readinessProbe = getSidecarProbe(config.getReadinessProbe().getHttpProbe());
+      TemplatedResource readinessProbe = getSidecarProbe(config.getReadinessProbe());
       container.addBinding("readinessProbe", readinessProbe.toString());
     } else {
       container.addBinding("readinessProbe", null);
     }
 
     if (config.getLivenessProbe() != null) {
-      TemplatedResource livenessProbe = getSidecarProbe(config.getLivenessProbe().getHttpProbe());
+      TemplatedResource livenessProbe = getSidecarProbe(config.getLivenessProbe());
       container.addBinding("livenessProbe", livenessProbe.toString());
     } else {
       container.addBinding("livenessProbe", null);
     }
 
     if (config.getStartupProbe() != null) {
-      TemplatedResource startupProbe = getSidecarProbe(config.getStartupProbe().getHttpProbe());
+      TemplatedResource startupProbe = getSidecarProbe(config.getStartupProbe());
       container.addBinding("startupProbe", startupProbe.toString());
     } else {
       container.addBinding("startupProbe", null);

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -337,14 +337,73 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T>, Kubernete
     }
 
     TemplatedResource resources = new JinjaJarResource("/kubernetes/manifests/resources.yml");
-    SidecarConfig.Resources configResources = config.getResources();
-    if (configResources != null) {
-      if (configResources.getRequests() != null) {
-        resources.addBinding("requests", configResources.getRequests().toString());
-      }
-      if (configResources.getLimits() != null) {
-        resources.addBinding("limits", configResources.getLimits().toString());
-      }
+    if (config.getResources() != null) {
+      resources.addBinding("requests", config.getResources().getRequests());
+      resources.addBinding("limits", config.getResources().getLimits());
+      container.addBinding("resources", resources.toString());
+    } else {
+      container.addBinding("resources", null);
+    }
+
+    TemplatedResource livenessProbe = new JinjaJarResource("/kubernetes/manifests/httpProbe.yml");
+    if (config.getLivenessProbe() != null) {
+      livenessProbe.addBinding("port", config.getLivenessProbe().getHttpGet().getPort());
+      livenessProbe.addBinding("path", config.getLivenessProbe().getHttpGet().getPath());
+      livenessProbe.addBinding("scheme", config.getLivenessProbe().getHttpGet().getScheme());
+      livenessProbe.addBinding(
+          "initialDelaySeconds", config.getLivenessProbe().getHttpProbe().getInitialDelaySeconds());
+      livenessProbe.addBinding(
+          "periodSeconds", config.getLivenessProbe().getHttpProbe().getPeriodSeconds());
+      livenessProbe.addBinding(
+          "timeoutSeconds", config.getLivenessProbe().getHttpProbe().getTimeoutSeconds());
+      livenessProbe.addBinding(
+          "successThreshold", config.getLivenessProbe().getHttpProbe().getSuccessThreshold());
+      livenessProbe.addBinding(
+          "failureThreshold", config.getLivenessProbe().getHttpProbe().getFailureThreshold());
+      container.addBinding("livenessProbe", livenessProbe.toString());
+    } else {
+      container.addBinding("livenessProbe", null);
+    }
+
+    TemplatedResource readinessProbe = new JinjaJarResource("/kubernetes/manifests/httpProbe.yml");
+    if (config.getReadinessProbe() != null) {
+      readinessProbe.addBinding("port", config.getReadinessProbe().getHttpGet().getPort());
+      readinessProbe.addBinding("path", config.getReadinessProbe().getHttpGet().getPath());
+      readinessProbe.addBinding("scheme", config.getReadinessProbe().getHttpGet().getScheme());
+      readinessProbe.addBinding(
+          "initialDelaySeconds",
+          config.getReadinessProbe().getHttpProbe().getInitialDelaySeconds());
+      readinessProbe.addBinding(
+          "periodSeconds", config.getReadinessProbe().getHttpProbe().getPeriodSeconds());
+      readinessProbe.addBinding(
+          "timeoutSeconds", config.getReadinessProbe().getHttpProbe().getTimeoutSeconds());
+      readinessProbe.addBinding(
+          "failureThreshold", config.getReadinessProbe().getHttpProbe().getFailureThreshold());
+      readinessProbe.addBinding(
+          "successThreshold", config.getReadinessProbe().getHttpProbe().getSuccessThreshold());
+      container.addBinding("readinessProbe", readinessProbe.toString());
+    } else {
+      container.addBinding("readinessProbe", null);
+    }
+
+    TemplatedResource startupProbe = new JinjaJarResource("/kubernetes/manifests/httpProbe.yml");
+    if (config.getStartupProbe() != null) {
+      startupProbe.addBinding("port", config.getStartupProbe().getHttpGet().getPort());
+      startupProbe.addBinding("path", config.getStartupProbe().getHttpGet().getPath());
+      startupProbe.addBinding("scheme", config.getStartupProbe().getHttpGet().getScheme());
+      startupProbe.addBinding(
+          "initialDelaySeconds", config.getStartupProbe().getHttpProbe().getInitialDelaySeconds());
+      startupProbe.addBinding(
+          "periodSeconds", config.getStartupProbe().getHttpProbe().getPeriodSeconds());
+      startupProbe.addBinding(
+          "timeoutSeconds", config.getStartupProbe().getHttpProbe().getTimeoutSeconds());
+      startupProbe.addBinding(
+          "failureThreshold", config.getStartupProbe().getHttpProbe().getFailureThreshold());
+      startupProbe.addBinding(
+          "successThreshold", config.getStartupProbe().getHttpProbe().getSuccessThreshold());
+      container.addBinding("startupProbe", startupProbe.toString());
+    } else {
+      container.addBinding("startupProbe", null);
     }
 
     container.addBinding("name", config.getName());
@@ -352,11 +411,8 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T>, Kubernete
     container.addBinding("command", config.getCommand());
     container.addBinding("args", config.getArgs());
     container.addBinding("volumeMounts", volumeMounts);
-    container.addBinding("readinessProbe", config.getReadinessProbe());
-    container.addBinding("livenessProbe", config.getLivenessProbe());
     container.addBinding("lifecycle", null);
     container.addBinding("env", config.getEnv());
-    container.addBinding("resources", resources);
 
     return container.toString();
   }

--- a/halyard-deploy/src/main/resources/kubernetes/manifests/container.yml
+++ b/halyard-deploy/src/main/resources/kubernetes/manifests/container.yml
@@ -25,6 +25,8 @@
 
   "livenessProbe": {{ livenessProbe }},
 
+  "startupProbe": {{ startupProbe }},
+
   "securityContext": {{ securityContext }},
 
   "volumeMounts": [

--- a/halyard-deploy/src/main/resources/kubernetes/manifests/execProbe.yml
+++ b/halyard-deploy/src/main/resources/kubernetes/manifests/execProbe.yml
@@ -1,10 +1,29 @@
 {
+  {% if initialDelaySeconds != null %}
+  "initialDelaySeconds": {{ initialDelaySeconds }},
+  {% endif %}
+
+  {% if periodSeconds != null %}
+  "periodSeconds": {{ periodSeconds }},
+  {% endif %}
+
+  {% if timeoutSeconds != null %}
+  "timeoutSeconds": {{ timeoutSeconds }},
+  {% endif %}
+
+  {% if failureThreshold != null %}
+  "failureThreshold": {{ failureThreshold }},
+  {% endif %}
+
+  {% if successThreshold != null %}
+  "successThreshold": {{ successThreshold }},
+  {% endif %}
+
   "exec": {
     "command": [
       {% for token in command %}
-              "{{ token }}"{% if not loop.last %}, {% endif %}
+      "{{ token }}"{% if not loop.last %}, {% endif %}
       {% endfor %}
     ]
-  },
-  "initialDelaySeconds": {{ initialDelaySeconds }}
+  }
 }

--- a/halyard-deploy/src/main/resources/kubernetes/manifests/httpProbe.yml
+++ b/halyard-deploy/src/main/resources/kubernetes/manifests/httpProbe.yml
@@ -2,7 +2,28 @@
   "httpGet": {
     "port": {{ port }},
     "path": "{{ path }}",
-    "scheme": "{{ scheme }}"
+    {% if scheme != null %}
+      "scheme": "{{ scheme }}"
+    {% endif %}
   },
-  "initialDelaySeconds": {{ initialDelaySeconds }}
+
+  {% if initialDelaySeconds != null %}
+    "initialDelaySeconds": {{ initialDelaySeconds }}
+  {% endif %}
+
+  {% if periodSeconds != null %}
+    "periodSeconds": {{ periodSeconds }}
+  {% endif %}
+
+  {% if timeoutSeconds != null %}
+    "timeoutSeconds": {{ timeoutSeconds }}
+  {% endif %}
+
+  {% if failureThreshold != null %}
+    "failureThreshold": {{ failureThreshold }}
+  {% endif %}
+
+  {% if successThreshold != null %}
+    "successThreshold": {{ successThreshold }}
+  {% endif %}
 }

--- a/halyard-deploy/src/main/resources/kubernetes/manifests/httpProbe.yml
+++ b/halyard-deploy/src/main/resources/kubernetes/manifests/httpProbe.yml
@@ -20,7 +20,7 @@
   {% endif %}
 
   "httpGet": {
-    {% if httpHeaders != null }
+    {% if httpHeaders != null %}
     "httpHeaders": [
       {% for header in httpHeaders %}
       { "name": "{{ header.name }}", "value": "{{ header.value }}" } {% if not loop.last %} , {% endif %}
@@ -31,7 +31,7 @@
     {% if scheme != null %}
     "scheme": "{{ scheme }}",
     {% endif %}
-    "port": "{{ port }}",
+    "port": {{ port }},
     "path": "{{ path }}"
   }
 }

--- a/halyard-deploy/src/main/resources/kubernetes/manifests/httpProbe.yml
+++ b/halyard-deploy/src/main/resources/kubernetes/manifests/httpProbe.yml
@@ -1,29 +1,37 @@
 {
-  "httpGet": {
-    "port": {{ port }},
-    "path": "{{ path }}",
-    {% if scheme != null %}
-      "scheme": "{{ scheme }}"
-    {% endif %}
-  },
-
   {% if initialDelaySeconds != null %}
-    "initialDelaySeconds": {{ initialDelaySeconds }}
+  "initialDelaySeconds": {{ initialDelaySeconds }},
   {% endif %}
 
   {% if periodSeconds != null %}
-    "periodSeconds": {{ periodSeconds }}
+  "periodSeconds": {{ periodSeconds }},
   {% endif %}
 
   {% if timeoutSeconds != null %}
-    "timeoutSeconds": {{ timeoutSeconds }}
+  "timeoutSeconds": {{ timeoutSeconds }},
   {% endif %}
 
   {% if failureThreshold != null %}
-    "failureThreshold": {{ failureThreshold }}
+  "failureThreshold": {{ failureThreshold }},
   {% endif %}
 
   {% if successThreshold != null %}
-    "successThreshold": {{ successThreshold }}
+  "successThreshold": {{ successThreshold }},
   {% endif %}
+
+  "httpGet": {
+    {% if httpHeaders != null }
+    "httpHeaders": [
+      {% for header in httpHeaders %}
+      { "name": "{{ header.name }}", "value": "{{ header.value }}" } {% if not loop.last %} , {% endif %}
+      {% endfor %}
+    ],
+    {% endif %}
+
+    {% if scheme != null %}
+    "scheme": "{{ scheme }}",
+    {% endif %}
+    "port": "{{ port }}",
+    "path": "{{ path }}"
+  }
 }

--- a/halyard-deploy/src/main/resources/kubernetes/manifests/tcpSocketProbe.yml
+++ b/halyard-deploy/src/main/resources/kubernetes/manifests/tcpSocketProbe.yml
@@ -1,6 +1,24 @@
 {
+  {% if initialDelaySeconds != null %}
+  "initialDelaySeconds": {{ initialDelaySeconds }},
+  {% endif %}
+
+  {% if periodSeconds != null %}
+  "periodSeconds": {{ periodSeconds }},
+  {% endif %}
+
+  {% if timeoutSeconds != null %}
+  "timeoutSeconds": {{ timeoutSeconds }},
+  {% endif %}
+
+  {% if failureThreshold != null %}
+  "failureThreshold": {{ failureThreshold }},
+  {% endif %}
+
+  {% if successThreshold != null %}
+  "successThreshold": {{ successThreshold }},
+  {% endif %}
   "tcpSocket": {
     "port": {{ port }}
-  },
-  "initialDelaySeconds": {{ initialDelaySeconds }}
+  }
 }

--- a/halyard-deploy/src/main/resources/kubernetes/manifests/tcpSocketProbe.yml
+++ b/halyard-deploy/src/main/resources/kubernetes/manifests/tcpSocketProbe.yml
@@ -1,7 +1,8 @@
 {
-  {% if initialDelaySeconds != null %}
   "initialDelaySeconds": {{ initialDelaySeconds }},
-  {% endif %}
+  "tcpSocket": {
+    "port": {{ port }}
+  },
 
   {% if periodSeconds != null %}
   "periodSeconds": {{ periodSeconds }},
@@ -11,14 +12,11 @@
   "timeoutSeconds": {{ timeoutSeconds }},
   {% endif %}
 
-  {% if failureThreshold != null %}
-  "failureThreshold": {{ failureThreshold }},
-  {% endif %}
-
   {% if successThreshold != null %}
   "successThreshold": {{ successThreshold }},
   {% endif %}
-  "tcpSocket": {
-    "port": {{ port }}
-  }
+
+  {% if failureThreshold != null %}
+  "failureThreshold": {{ failureThreshold }}
+  {% endif %}
 }

--- a/halyard-deploy/src/test/groovy/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2ServiceTest.groovy
+++ b/halyard-deploy/src/test/groovy/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2ServiceTest.groovy
@@ -420,11 +420,10 @@ class KubernetesV2ServiceTest extends Specification {
 
         then:
         yaml.contains('''"readinessProbe": {
+  "initialDelaySeconds": ,
   "tcpSocket": {
     "port": 8000
   },
-  "initialDelaySeconds": 
-}
 ''')
     }
 


### PR DESCRIPTION
[SPLAT-133]

This improves sidecar support to allow for the configuration of resources for their container as well additional probe types (readiness and liveness).  TCP, HTTP, and Exec options are now supported and some probe fields that were previously missing have been added. 

*Note: this PR also adds `startupProbe`. However, the Operator is currently matched against Kubernetes 1.14 which is prior to the introduction of Startup Probes (in kubernetes 1.17, I believe).  Support for Startup Probes should come for free when/if Operator is updated for current versions of kubernetes.

[SPLAT-133]: https://armory.atlassian.net/browse/SPLAT-133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ