### PR TITLE
fix(container): Operator 1.7.x introduces aggressive & unwanted startupProbe, failing pods on startup.

### DIFF
--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -26,7 +26,7 @@ RUN apk update \
     && apk upgrade \
     && rm -rf /var/cache/apk/* \
     && apk add musl=1.1.24-r10 \
-    && apk add krb5-libs=1.18.4-r0
+    && apk add krb5-libs=1.18.5-r0
 
 # Google cloud SDK with anthos removed for CVE and because we don't need it
 RUN wget -nv https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GOOGLE_CLOUD_SDK_VERSION}-linux-x86_64.tar.gz \

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -6207,8 +6207,6 @@ This is only required when Spinnaker is being deployed in non-Kubernetes cluster
 	java8: A variant of slim that uses the Java 8 runtime
 	ubuntu-java8: A variant of ubuntu that uses the Java 8 runtime
 Default value: slim
- * `--liveness-probe-enabled`: When true, enable Kubernetes liveness probes on Spinnaker services deployed in a Distributed installation. See docs for more information: [https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/)
- * `--liveness-probe-initial-delay-seconds`: The number of seconds to wait before performing the first liveness probe. Should be set to the longest service startup time. See docs for more information: [https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/)
  * `--location`: This is the location spinnaker will be deployed to. When deploying to Kubernetes, use this flag to specify the namespace to deploy to (defaults to 'spinnaker')
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--type`: Distributed: Deploy Spinnaker with one server group per microservice, and a single shared Redis.

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditDeploymentEnvironmentCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditDeploymentEnvironmentCommand.java
@@ -129,20 +129,6 @@ public class EditDeploymentEnvironmentCommand extends AbstractConfigCommand {
       description = "This is the git user your github fork exists under.")
   private String gitOriginUser;
 
-  @Parameter(
-      names = "--liveness-probe-enabled",
-      arity = 1,
-      description =
-          "When true, enable Kubernetes liveness probes on Spinnaker services deployed in a Distributed installation. See docs for more information: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/")
-  private Boolean livenessProbesEnabled;
-
-  @Parameter(
-      names = "--liveness-probe-initial-delay-seconds",
-      arity = 1,
-      description =
-          "The number of seconds to wait before performing the first liveness probe. Should be set to the longest service startup time. See docs for more information: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/")
-  private Integer livenessProbeInitialDelaySeconds;
-
   @Override
   protected void executeThis() {
     String currentDeployment = getCurrentDeployment();
@@ -175,12 +161,6 @@ public class EditDeploymentEnvironmentCommand extends AbstractConfigCommand {
       vault = new DeploymentEnvironment.Vault();
     }
 
-    DeploymentEnvironment.LivenessProbeConfig livenessProbeConfig =
-        deploymentEnvironment.getLivenessProbeConfig();
-    if (livenessProbeConfig == null) {
-      livenessProbeConfig = new DeploymentEnvironment.LivenessProbeConfig();
-    }
-
     deploymentEnvironment.setAccountName(
         isSet(accountName) ? accountName : deploymentEnvironment.getAccountName());
     deploymentEnvironment.setBootstrapOnly(
@@ -196,14 +176,6 @@ public class EditDeploymentEnvironmentCommand extends AbstractConfigCommand {
     vault.setAddress(isSet(vaultAddress) ? vaultAddress : vault.getAddress());
     vault.setEnabled(isSet(vaultEnabled) ? vaultEnabled : vault.isEnabled());
     deploymentEnvironment.setVault(vault);
-
-    if (isSet(livenessProbesEnabled)) {
-      livenessProbeConfig.setEnabled(livenessProbesEnabled);
-    }
-    if (isSet(livenessProbeInitialDelaySeconds)) {
-      livenessProbeConfig.setInitialDelaySeconds(livenessProbeInitialDelaySeconds);
-    }
-    deploymentEnvironment.setLivenessProbeConfig(livenessProbeConfig);
 
     deploymentEnvironment.setLocation(
         isSet(location) ? location : deploymentEnvironment.getLocation());

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/DeploymentEnvironment.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/DeploymentEnvironment.java
@@ -137,7 +137,6 @@ public class DeploymentEnvironment extends Node {
   private Map<String, List<Toleration>> tolerations = new HashMap<>();
   private Map<String, String> nodeSelectors = new HashMap<>();
   private GitConfig gitConfig = new GitConfig();
-  private LivenessProbeConfig livenessProbeConfig = new LivenessProbeConfig();
 
   @ValidForSpinnakerVersion(
       lowerBound = "1.10.0",
@@ -165,11 +164,5 @@ public class DeploymentEnvironment extends Node {
   public static class GitConfig {
     String upstreamUser = "spinnaker";
     String originUser;
-  }
-
-  @Data
-  public static class LivenessProbeConfig {
-    boolean enabled;
-    Integer initialDelaySeconds;
   }
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/KubernetesProbe.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/KubernetesProbe.java
@@ -1,0 +1,41 @@
+package com.netflix.spinnaker.halyard.config.model.v1.node;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class KubernetesProbe {
+  Integer initialDelaySeconds;
+  Integer periodSeconds;
+  Integer timeoutSeconds;
+  Integer successThreshold;
+  Integer failureThreshold;
+  HttpGet httpGet;
+  TcpSocket tcpSocket;
+  Exec exec;
+
+  @Data
+  public static class TcpSocket {
+    Integer port;
+  }
+
+  @Data
+  public static class HttpGet {
+    Integer port;
+    String path;
+    String scheme;
+    List<HttpHeaders> httpHeaders = new ArrayList<>();
+  }
+
+  @Data
+  public static class Exec {
+    List<String> command = new ArrayList<>();
+  }
+
+  @Data
+  public static class HttpHeaders {
+    String name;
+    String value;
+  }
+}

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/SidecarConfig.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/SidecarConfig.java
@@ -32,9 +32,9 @@ public class SidecarConfig {
   List<ConfigMapVolumeMount> configMapVolumeMounts = new ArrayList<>();
   List<SecretVolumeMount> secretVolumeMounts = new ArrayList<>();
   Resources resources;
-  Probe livenessProbe;
-  Probe readinessProbe;
-  Probe startupProbe;
+  KubernetesProbe livenessProbe;
+  KubernetesProbe readinessProbe;
+  KubernetesProbe startupProbe;
   String mountPath;
   SecurityContext securityContext;
 
@@ -59,41 +59,5 @@ public class SidecarConfig {
   public static class Resources {
     Map<String, String> requests = new HashMap<>();
     Map<String, String> limits = new HashMap<>();
-  }
-
-  @Data
-  public static class Probe {
-    Integer initialDelaySeconds;
-    Integer periodSeconds;
-    Integer timeoutSeconds;
-    Integer successThreshold;
-    Integer failureThreshold;
-    HttpGet httpGet;
-    TcpSocket tcpSocket;
-    Exec exec;
-  }
-
-  @Data
-  public static class TcpSocket {
-    Integer port;
-  }
-
-  @Data
-  public static class HttpGet {
-    Integer port;
-    String path;
-    String scheme;
-    List<HttpHeaders> httpHeaders = new ArrayList<>();
-  }
-
-  @Data
-  public static class Exec {
-    List<String> command = new ArrayList<>();
-  }
-
-  @Data
-  public static class HttpHeaders {
-    String name;
-    String value;
   }
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/DeploymentEnvironmentValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/DeploymentEnvironmentValidator.java
@@ -61,8 +61,6 @@ public class DeploymentEnvironmentValidator extends Validator<DeploymentEnvironm
       default:
         throw new RuntimeException("Unknown deployment environment type " + type);
     }
-
-    validateLivenessProbeConfig(p, n);
   }
 
   private void validateGitDeployment(ConfigProblemSetBuilder p, DeploymentEnvironment n) {
@@ -113,16 +111,6 @@ public class DeploymentEnvironmentValidator extends Validator<DeploymentEnvironm
           "Account "
               + accountName
               + " is not in a provider that supports distributed installation of Spinnaker yet");
-    }
-  }
-
-  private void validateLivenessProbeConfig(ConfigProblemSetBuilder p, DeploymentEnvironment n) {
-    if (n.getLivenessProbeConfig() != null && n.getLivenessProbeConfig().isEnabled()) {
-      if (n.getLivenessProbeConfig().getInitialDelaySeconds() == null) {
-        p.addProblem(
-            Problem.Severity.FATAL,
-            "Setting `initialDelaySeconds` is required when enabling liveness probes. Use the --liveness-probe-initial-delay-seconds sub-command to set `initialDelaySeconds`.");
-      }
     }
   }
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/KubernetesSettings.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/KubernetesSettings.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service;
 
+import com.netflix.spinnaker.halyard.config.model.v1.node.KubernetesProbe;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -41,4 +42,8 @@ public class KubernetesSettings {
   Boolean useTcpProbe = false;
   KubernetesSecurityContext securityContext = null;
   DeploymentStrategy deploymentStrategy = null;
+
+  KubernetesProbe livenessProbe;
+  KubernetesProbe readinessProbe;
+  KubernetesProbe startupProbe;
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -20,12 +20,7 @@ package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.ku
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.netflix.spinnaker.halyard.config.model.v1.node.AffinityConfig;
-import com.netflix.spinnaker.halyard.config.model.v1.node.CustomSizing;
-import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
-import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentEnvironment;
-import com.netflix.spinnaker.halyard.config.model.v1.node.SidecarConfig;
-import com.netflix.spinnaker.halyard.config.model.v1.node.Toleration;
+import com.netflix.spinnaker.halyard.config.model.v1.node.*;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.kubernetes.KubernetesAccount;
 import com.netflix.spinnaker.halyard.core.error.v1.HalException;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
@@ -346,21 +341,21 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T>, Kubernete
     }
 
     if (config.getReadinessProbe() != null) {
-      TemplatedResource readinessProbe = getSidecarProbe(config.getReadinessProbe());
+      TemplatedResource readinessProbe = getProbe(config.getReadinessProbe());
       container.addBinding("readinessProbe", readinessProbe.toString());
     } else {
       container.addBinding("readinessProbe", null);
     }
 
     if (config.getLivenessProbe() != null) {
-      TemplatedResource livenessProbe = getSidecarProbe(config.getLivenessProbe());
+      TemplatedResource livenessProbe = getProbe(config.getLivenessProbe());
       container.addBinding("livenessProbe", livenessProbe.toString());
     } else {
       container.addBinding("livenessProbe", null);
     }
 
     if (config.getStartupProbe() != null) {
-      TemplatedResource startupProbe = getSidecarProbe(config.getStartupProbe());
+      TemplatedResource startupProbe = getProbe(config.getStartupProbe());
       container.addBinding("startupProbe", startupProbe.toString());
     } else {
       container.addBinding("startupProbe", null);
@@ -377,7 +372,7 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T>, Kubernete
     return container.toString();
   }
 
-  default TemplatedResource getSidecarProbe(SidecarConfig.Probe probe) {
+  default TemplatedResource getProbe(KubernetesProbe probe) {
     TemplatedResource tr;
     if (probe.getHttpGet() != null) {
       tr = new JinjaJarResource("/kubernetes/manifests/httpProbe.yml");
@@ -464,20 +459,52 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T>, Kubernete
     container.addBinding("port", port.toString());
     container.addBinding("volumeMounts", volumeMounts);
 
-    TemplatedResource readinessProbe = getProbe(settings, null);
-    container.addBinding("readinessProbe", readinessProbe.toString());
+    KubernetesSettings kubernetesSettings = settings.getKubernetes();
 
-    TemplatedResource startupProbe = getProbe(settings, null);
-    container.addBinding("startupProbe", startupProbe.toString());
+    if (kubernetesSettings.getReadinessProbe() != null) {
+      TemplatedResource readinessProbe = getProbe(kubernetesSettings.getReadinessProbe());
+      container.addBinding("readinessProbe", readinessProbe.toString());
+    } else {
+      if (kubernetesSettings.getReadinessProbe() != null) {
+        TemplatedResource readinessProbe = getProbe(kubernetesSettings.getReadinessProbe());
+        container.addBinding("readinessProbe", readinessProbe.toString());
+      } else {
+        KubernetesProbe defaultReadinessProbe = new KubernetesProbe();
 
-    DeploymentEnvironment.LivenessProbeConfig livenessProbeConfig =
-        deploymentEnvironment.getLivenessProbeConfig();
-    if (livenessProbeConfig != null
-        && livenessProbeConfig.isEnabled()
-        && livenessProbeConfig.getInitialDelaySeconds() != null) {
-      TemplatedResource livenessProbe =
-          getProbe(settings, livenessProbeConfig.getInitialDelaySeconds());
+        if (StringUtils.isEmpty(settings.getHealthEndpoint())
+            || settings.getKubernetes().getUseTcpProbe()) {
+          KubernetesProbe.TcpSocket tcpSocket = new KubernetesProbe.TcpSocket();
+          tcpSocket.setPort(settings.getPort());
+          defaultReadinessProbe.setTcpSocket(tcpSocket);
+        } else if (kubernetesSettings.getUseExecHealthCheck()) {
+          KubernetesProbe.Exec exec = new KubernetesProbe.Exec();
+          exec.setCommand(getReadinessExecCommand(settings));
+          defaultReadinessProbe.setExec(exec);
+        } else {
+          KubernetesProbe.HttpGet httpGet = new KubernetesProbe.HttpGet();
+          httpGet.setPath(settings.getHealthEndpoint());
+          httpGet.setPort(settings.getPort());
+          httpGet.setScheme(settings.getScheme().toUpperCase());
+          defaultReadinessProbe.setHttpGet(httpGet);
+        }
+
+        TemplatedResource readinessProbe = getProbe(defaultReadinessProbe);
+        container.addBinding("readinessProbe", readinessProbe.toString());
+      }
+    }
+
+    if (kubernetesSettings.getLivenessProbe() != null) {
+      TemplatedResource livenessProbe = getProbe(kubernetesSettings.getLivenessProbe());
       container.addBinding("livenessProbe", livenessProbe.toString());
+    } else {
+      container.addBinding("livenessProbe", null);
+    }
+
+    if (kubernetesSettings.getStartupProbe() != null) {
+      TemplatedResource startupProbe = getProbe(kubernetesSettings.getStartupProbe());
+      container.addBinding("startupProbe", startupProbe.toString());
+    } else {
+      container.addBinding("startupProbe", null);
     }
 
     container.addBinding("lifecycle", lifecycle);
@@ -485,25 +512,6 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T>, Kubernete
     container.addBinding("resources", resources.toString());
 
     return container.toString();
-  }
-
-  default TemplatedResource getProbe(ServiceSettings settings, Integer initialDelaySeconds) {
-    TemplatedResource probe;
-    if (StringUtils.isEmpty(settings.getHealthEndpoint())
-        || settings.getKubernetes().getUseTcpProbe()) {
-      probe = new JinjaJarResource("/kubernetes/manifests/tcpSocketProbe.yml");
-      probe.addBinding("port", settings.getPort());
-    } else if (settings.getKubernetes().getUseExecHealthCheck()) {
-      probe = new JinjaJarResource("/kubernetes/manifests/execProbe.yml");
-      probe.addBinding("command", getReadinessExecCommand(settings));
-    } else {
-      probe = new JinjaJarResource("/kubernetes/manifests/httpProbe.yml");
-      probe.addBinding("port", settings.getPort());
-      probe.addBinding("path", settings.getHealthEndpoint());
-      probe.addBinding("scheme", settings.getScheme().toUpperCase());
-    }
-    probe.addBinding("initialDelaySeconds", initialDelaySeconds);
-    return probe;
   }
 
   default String getNamespace(ServiceSettings settings) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -465,32 +465,27 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T>, Kubernete
       TemplatedResource readinessProbe = getProbe(kubernetesSettings.getReadinessProbe());
       container.addBinding("readinessProbe", readinessProbe.toString());
     } else {
-      if (kubernetesSettings.getReadinessProbe() != null) {
-        TemplatedResource readinessProbe = getProbe(kubernetesSettings.getReadinessProbe());
-        container.addBinding("readinessProbe", readinessProbe.toString());
+      KubernetesProbe defaultReadinessProbe = new KubernetesProbe();
+
+      if (StringUtils.isEmpty(settings.getHealthEndpoint())
+          || settings.getKubernetes().getUseTcpProbe()) {
+        KubernetesProbe.TcpSocket tcpSocket = new KubernetesProbe.TcpSocket();
+        tcpSocket.setPort(settings.getPort());
+        defaultReadinessProbe.setTcpSocket(tcpSocket);
+      } else if (kubernetesSettings.getUseExecHealthCheck()) {
+        KubernetesProbe.Exec exec = new KubernetesProbe.Exec();
+        exec.setCommand(getReadinessExecCommand(settings));
+        defaultReadinessProbe.setExec(exec);
       } else {
-        KubernetesProbe defaultReadinessProbe = new KubernetesProbe();
-
-        if (StringUtils.isEmpty(settings.getHealthEndpoint())
-            || settings.getKubernetes().getUseTcpProbe()) {
-          KubernetesProbe.TcpSocket tcpSocket = new KubernetesProbe.TcpSocket();
-          tcpSocket.setPort(settings.getPort());
-          defaultReadinessProbe.setTcpSocket(tcpSocket);
-        } else if (kubernetesSettings.getUseExecHealthCheck()) {
-          KubernetesProbe.Exec exec = new KubernetesProbe.Exec();
-          exec.setCommand(getReadinessExecCommand(settings));
-          defaultReadinessProbe.setExec(exec);
-        } else {
-          KubernetesProbe.HttpGet httpGet = new KubernetesProbe.HttpGet();
-          httpGet.setPath(settings.getHealthEndpoint());
-          httpGet.setPort(settings.getPort());
-          httpGet.setScheme(settings.getScheme().toUpperCase());
-          defaultReadinessProbe.setHttpGet(httpGet);
-        }
-
-        TemplatedResource readinessProbe = getProbe(defaultReadinessProbe);
-        container.addBinding("readinessProbe", readinessProbe.toString());
+        KubernetesProbe.HttpGet httpGet = new KubernetesProbe.HttpGet();
+        httpGet.setPath(settings.getHealthEndpoint());
+        httpGet.setPort(settings.getPort());
+        httpGet.setScheme(settings.getScheme().toUpperCase());
+        defaultReadinessProbe.setHttpGet(httpGet);
       }
+
+      TemplatedResource readinessProbe = getProbe(defaultReadinessProbe);
+      container.addBinding("readinessProbe", readinessProbe.toString());
     }
 
     if (kubernetesSettings.getLivenessProbe() != null) {

--- a/halyard-deploy/src/test/groovy/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2ServiceTest.groovy
+++ b/halyard-deploy/src/test/groovy/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2ServiceTest.groovy
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.halyard.config.config.v1.StrictObjectMapper
 import com.netflix.spinnaker.halyard.config.model.v1.node.AffinityConfig
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration
+import com.netflix.spinnaker.halyard.config.model.v1.node.KubernetesProbe
 import com.netflix.spinnaker.halyard.config.model.v1.node.SidecarConfig
 import com.netflix.spinnaker.halyard.config.model.v1.node.Toleration
 import com.netflix.spinnaker.halyard.config.model.v1.providers.kubernetes.KubernetesAccount
@@ -408,7 +409,7 @@ class KubernetesV2ServiceTest extends Specification {
         podSpecYaml.contains('"serviceAccountName": customServiceAccount')
     }
 
-    def "Can we use TCP probe"() {
+    def "should use default TCP probe"() {
         setup:
         def settings = new KubernetesSettings()
         settings.useTcpProbe = true
@@ -427,13 +428,14 @@ class KubernetesV2ServiceTest extends Specification {
 ''')
     }
 
-    def "Readiness probe"() {
+    def "should use default readiness probe"() {
         setup:
         def settings = new KubernetesSettings()
         serviceSettings.kubernetes = settings
         serviceSettings.port = 8000
         serviceSettings.scheme = "http"
         serviceSettings.healthEndpoint = "/health"
+
         if (tcpProbe != null) {
             settings.useTcpProbe = tcpProbe
         }
@@ -442,7 +444,7 @@ class KubernetesV2ServiceTest extends Specification {
         }
 
         when:
-        String yaml = testService.getProbe(serviceSettings, null).toString()
+        String yaml = testService.buildContainer("orca", details, serviceSettings, new ArrayList<>(), new HashMap<>())
 
         then:
         yaml.contains(readinessProbeResult)
@@ -453,6 +455,192 @@ class KubernetesV2ServiceTest extends Specification {
         "tcpProbe on"       | true       | null         | "tcpSocket"
         "tcpProbe off"      | false      | null         | "exec"
         "exec probe on"     | null       | true         | "exec"
-        "exec probe off"    | null      | false       | "http"
+        "exec probe off"    | null       | false        | "http"
+    }
+
+    def "should use overridden readiness HTTP probe"() {
+        setup:
+        def httpGet = new KubernetesProbe.HttpGet()
+        httpGet.setPath("/health")
+        httpGet.setPort(8000)
+        httpGet.setScheme("http")
+
+        def probe = new KubernetesProbe()
+        probe.setHttpGet(httpGet)
+
+        def settings = new KubernetesSettings()
+        settings.setReadinessProbe(probe)
+
+        serviceSettings.kubernetes = settings
+
+        when:
+        String yaml = testService.buildContainer("orca", details, serviceSettings, new ArrayList<>(), new HashMap<>())
+
+        then:
+        yaml.contains("http")
+    }
+
+    def "should use overridden readiness TCP Socket probe"() {
+        setup:
+        def tcpSocket = new KubernetesProbe.TcpSocket()
+        tcpSocket.setPort(8000)
+
+        def probe = new KubernetesProbe()
+        probe.setTcpSocket(tcpSocket)
+
+        def settings = new KubernetesSettings()
+        settings.setReadinessProbe(probe)
+
+        serviceSettings.kubernetes = settings
+
+        when:
+        String yaml = testService.buildContainer("orca", details, serviceSettings, new ArrayList<>(), new HashMap<>())
+
+        then:
+        yaml.contains("tcpSocket")
+    }
+
+    def "should use overridden readiness Exec probe"() {
+        setup:
+        def exec = new KubernetesProbe.Exec()
+        exec.setCommand(["- wget", "--no-check-certificate", "--spider", "-q", "http://localhost:8000/health"])
+
+        def probe = new KubernetesProbe()
+        probe.setExec(exec)
+
+        def settings = new KubernetesSettings()
+        settings.setReadinessProbe(probe)
+
+        serviceSettings.kubernetes = settings
+
+        when:
+        String yaml = testService.buildContainer("orca", details, serviceSettings, new ArrayList<>(), new HashMap<>())
+
+        then:
+        yaml.contains("exec")
+    }
+
+    def "should use overridden liveness HTTP probe"() {
+        setup:
+        def httpGet = new KubernetesProbe.HttpGet()
+        httpGet.setPath("/health")
+        httpGet.setPort(8000)
+        httpGet.setScheme("http")
+
+        def probe = new KubernetesProbe()
+        probe.setHttpGet(httpGet)
+
+        def settings = new KubernetesSettings()
+        settings.setLivenessProbe(probe)
+
+        serviceSettings.kubernetes = settings
+
+        when:
+        String yaml = testService.buildContainer("orca", details, serviceSettings, new ArrayList<>(), new HashMap<>())
+
+        then:
+        yaml.contains("http")
+    }
+
+    def "should use overridden liveness TCP Socket probe"() {
+        setup:
+        def tcpSocket = new KubernetesProbe.TcpSocket()
+        tcpSocket.setPort(8000)
+
+        def probe = new KubernetesProbe()
+        probe.setTcpSocket(tcpSocket)
+
+        def settings = new KubernetesSettings()
+        settings.setLivenessProbe(probe)
+
+        serviceSettings.kubernetes = settings
+
+        when:
+        String yaml = testService.buildContainer("orca", details, serviceSettings, new ArrayList<>(), new HashMap<>())
+
+        then:
+        yaml.contains("tcpSocket")
+    }
+
+    def "should use overridden liveness Exec probe"() {
+        setup:
+        def exec = new KubernetesProbe.Exec()
+        exec.setCommand(["- wget", "--no-check-certificate", "--spider", "-q", "http://localhost:8000/health"])
+
+        def probe = new KubernetesProbe()
+        probe.setExec(exec)
+
+        def settings = new KubernetesSettings()
+        settings.setLivenessProbe(probe)
+
+        serviceSettings.kubernetes = settings
+
+        when:
+        String yaml = testService.buildContainer("orca", details, serviceSettings, new ArrayList<>(), new HashMap<>())
+
+        then:
+        yaml.contains("exec")
+    }
+
+    def "should use overridden startup HTTP probe"() {
+        setup:
+        def httpGet = new KubernetesProbe.HttpGet()
+        httpGet.setPath("/health")
+        httpGet.setPort(8000)
+        httpGet.setScheme("http")
+
+        def probe = new KubernetesProbe()
+        probe.setHttpGet(httpGet)
+
+        def settings = new KubernetesSettings()
+        settings.setStartupProbe(probe)
+
+        serviceSettings.kubernetes = settings
+
+        when:
+        String yaml = testService.buildContainer("orca", details, serviceSettings, new ArrayList<>(), new HashMap<>())
+
+        then:
+        yaml.contains("http")
+    }
+
+    def "should use overridden startup TCP Socket probe"() {
+        setup:
+        def tcpSocket = new KubernetesProbe.TcpSocket()
+        tcpSocket.setPort(8000)
+
+        def probe = new KubernetesProbe()
+        probe.setTcpSocket(tcpSocket)
+
+        def settings = new KubernetesSettings()
+        settings.setStartupProbe(probe)
+
+        serviceSettings.kubernetes = settings
+
+        when:
+        String yaml = testService.buildContainer("orca", details, serviceSettings, new ArrayList<>(), new HashMap<>())
+
+        then:
+        yaml.contains("tcpSocket")
+    }
+
+    def "should use overridden startup Exec probe"() {
+        setup:
+        def exec = new KubernetesProbe.Exec()
+        exec.setCommand(["- wget", "--no-check-certificate", "--spider", "-q", "http://localhost:8000/health"])
+
+        def probe = new KubernetesProbe()
+        probe.setExec(exec)
+
+        def settings = new KubernetesSettings()
+        settings.setStartupProbe(probe)
+
+        serviceSettings.kubernetes = settings
+
+        when:
+        String yaml = testService.buildContainer("orca", details, serviceSettings, new ArrayList<>(), new HashMap<>())
+
+        then:
+        yaml.contains("exec")
     }
 }


### PR DESCRIPTION
https://armory.atlassian.net/browse/BOB-30749

How to use?

```yaml
apiVersion: spinnaker.armory.io/v1alpha2
kind: SpinnakerService
metadata:
  name: spinnaker
spec:
  spinnakerConfig:
    service-settings:
      clouddriver:
        kubernetes:
          livenessProbe:
            httpGet:
              port: 7002
              path: /health
              scheme: http
            initialDelaySeconds: 60
            periodSeconds: 10
            timeoutSeconds: 1
            successThreshold: 1
            failureThreshold: 3
          readinessProbe:
            tcpSocket:
              port: 7002
            initialDelaySeconds: 60
            periodSeconds: 10
            timeoutSeconds: 1
            successThreshold: 1
            failureThreshold: 3 
          startupProbe:
            exec:
              command:
                - wget
                - --no-check-certificate
                - --spider
                - -q
                - http://localhost:7002/health
            initialDelaySeconds: 60
            periodSeconds: 10
            timeoutSeconds: 1
            successThreshold: 1
            failureThreshold: 3
      echo: {}
      fiat: {}
      front50: {}
      gate: {}
      igor: {}
      kayenta: {}
      orca: {}
      rosco: {}
```