### PR TITLE
feat(config): Add Config Map data source for Spinnaker config.

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/KubernetesManifestExecutor.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/KubernetesManifestExecutor.java
@@ -14,13 +14,13 @@ import org.apache.commons.io.IOUtils;
 
 public abstract class KubernetesManifestExecutor {
 
-  public KubernetesV2Utils.SecretSpec createSecretSpec(
+  public KubernetesV2Utils.ResourceSpec createSecretSpec(
       String namespace,
       String clusterName,
       String name,
-      List<KubernetesV2Utils.SecretMountPair> files) {
+      List<KubernetesV2Utils.ResourceMountPair> files) {
     Map<String, String> contentMap = new HashMap<>();
-    for (KubernetesV2Utils.SecretMountPair pair : files) {
+    for (KubernetesV2Utils.ResourceMountPair pair : files) {
       String contents;
       if (pair.getContentBytes() != null) {
         contents = new String(Base64.getEncoder().encode(pair.getContentBytes()));
@@ -44,7 +44,7 @@ public abstract class KubernetesManifestExecutor {
       contentMap.put(pair.getName(), contents);
     }
 
-    KubernetesV2Utils.SecretSpec spec = new KubernetesV2Utils.SecretSpec();
+    KubernetesV2Utils.ResourceSpec spec = new KubernetesV2Utils.ResourceSpec();
     spec.setName(name + "-" + Math.abs(contentMap.hashCode()));
 
     spec.setResource(new JinjaJarResource("/kubernetes/manifests/secret.yml"));

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -39,7 +39,7 @@ import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.Dis
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.SidecarService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.kubernetes.KubernetesService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.kubernetes.KubernetesSharedServiceSettings;
-import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.kubernetes.v2.KubernetesV2Utils.SecretMountPair;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.kubernetes.v2.KubernetesV2Utils.ResourceMountPair;
 import java.io.File;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -609,13 +609,13 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T>, Kubernete
     for (Entry<String, Set<Profile>> entry : profilesByDirectory.entrySet()) {
       Set<Profile> profilesInDirectory = entry.getValue();
       String mountPath = entry.getKey();
-      List<SecretMountPair> files =
+      List<ResourceMountPair> files =
           profilesInDirectory.stream()
               .map(
                   p -> {
                     File input = new File(p.getStagedFile(stagingPath));
                     File output = new File(p.getOutputFile());
-                    return new SecretMountPair(input, output);
+                    return new ResourceMountPair(input, output);
                   })
               .collect(Collectors.toList());
 
@@ -626,36 +626,42 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T>, Kubernete
               .flatMap(Collection::stream)
               .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
 
-      KubernetesV2Utils.SecretSpec spec =
+      KubernetesV2Utils.ResourceSpec spec =
           executor
               .getKubernetesV2Utils()
-              .createSecretSpec(
-                  namespace, getService().getCanonicalName(), secretNamePrefix, files);
-      executor.replace(spec.resource.toString());
-      configSources.add(new ConfigSource().setId(spec.name).setMountPath(mountPath).setEnv(env));
-    }
-
-    if (!requiredFiles.isEmpty() || !requiredEncryptedFiles.isEmpty()) {
-      List<SecretMountPair> files =
-          requiredFiles.stream()
-              .map(File::new)
-              .map(SecretMountPair::new)
-              .collect(Collectors.toList());
-
-      // Add in memory decrypted files
-      requiredEncryptedFiles.keySet().stream()
-          .map(k -> new SecretMountPair(k, requiredEncryptedFiles.get(k)))
-          .forEach(s -> files.add(s));
-
-      KubernetesV2Utils.SecretSpec spec =
-          executor
-              .getKubernetesV2Utils()
-              .createSecretSpec(
+              .createResourceSpec(
                   namespace, getService().getCanonicalName(), secretNamePrefix, files);
       executor.replace(spec.resource.toString());
       configSources.add(
           new ConfigSource()
               .setId(spec.name)
+              .setType(spec.type)
+              .setMountPath(mountPath)
+              .setEnv(env));
+    }
+
+    if (!requiredFiles.isEmpty() || !requiredEncryptedFiles.isEmpty()) {
+      List<ResourceMountPair> files =
+          requiredFiles.stream()
+              .map(File::new)
+              .map(ResourceMountPair::new)
+              .collect(Collectors.toList());
+
+      // Add in memory decrypted files
+      requiredEncryptedFiles.keySet().stream()
+          .map(k -> new ResourceMountPair(k, requiredEncryptedFiles.get(k)))
+          .forEach(s -> files.add(s));
+
+      KubernetesV2Utils.ResourceSpec spec =
+          executor
+              .getKubernetesV2Utils()
+              .createResourceSpec(
+                  namespace, getService().getCanonicalName(), secretNamePrefix, files);
+      executor.replace(spec.resource.toString());
+      configSources.add(
+          new ConfigSource()
+              .setId(spec.name)
+              .setType(spec.type)
               .setMountPath(getSpinnakerStagingDependenciesPath(details.getDeploymentName())));
     }
 

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Utils.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Utils.java
@@ -27,6 +27,7 @@ import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
 import com.netflix.spinnaker.halyard.core.resource.v1.JinjaJarResource;
 import com.netflix.spinnaker.halyard.core.resource.v1.TemplatedResource;
 import com.netflix.spinnaker.halyard.core.secrets.v1.SecretSessionManager;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ConfigSource;
 import com.netflix.spinnaker.kork.configserver.CloudConfigResourceService;
 import java.io.File;
 import java.io.FileInputStream;
@@ -41,6 +42,7 @@ import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
@@ -50,6 +52,8 @@ import org.yaml.snakeyaml.constructor.SafeConstructor;
 public class KubernetesV2Utils {
   private final ObjectMapper mapper = new ObjectMapper();
 
+  private final ConfigSource.Type configSourceType;
+
   private final SecretSessionManager secretSessionManager;
 
   private final CloudConfigResourceService cloudConfigResourceService;
@@ -57,9 +61,11 @@ public class KubernetesV2Utils {
   private final FileService fileService;
 
   public KubernetesV2Utils(
+      @Value("${halyard.configSourceType:secret}") ConfigSource.Type configSourceType,
       SecretSessionManager secretSessionManager,
       CloudConfigResourceService cloudConfigResourceService,
       FileService fileService) {
+    this.configSourceType = configSourceType;
     this.secretSessionManager = secretSessionManager;
     this.cloudConfigResourceService = cloudConfigResourceService;
     this.fileService = fileService;
@@ -120,10 +126,10 @@ public class KubernetesV2Utils {
     return command;
   }
 
-  public SecretSpec createSecretSpec(
-      String namespace, String clusterName, String name, List<SecretMountPair> files) {
+  public ResourceSpec createResourceSpec(
+      String namespace, String clusterName, String name, List<ResourceMountPair> files) {
     Map<String, String> contentMap = new HashMap<>();
-    for (SecretMountPair pair : files) {
+    for (ResourceMountPair pair : files) {
       String contents;
       if (pair.getContentBytes() != null) {
         contents = new String(Base64.getEncoder().encode(pair.getContentBytes()));
@@ -147,10 +153,18 @@ public class KubernetesV2Utils {
       contentMap.put(pair.getName(), contents);
     }
 
-    SecretSpec spec = new SecretSpec();
+    ResourceSpec spec = new ResourceSpec();
     spec.name = name + "-" + Math.abs(contentMap.hashCode());
+    spec.type = configSourceType;
 
-    spec.resource = new JinjaJarResource("/kubernetes/manifests/secret.yml");
+    if (configSourceType == ConfigSource.Type.configMap) {
+      spec.resource = new JinjaJarResource("/kubernetes/manifests/configMap.yml");
+    }
+
+    if (configSourceType == ConfigSource.Type.secret) {
+      spec.resource = new JinjaJarResource("/kubernetes/manifests/secret.yml");
+    }
+
     Map<String, Object> bindings = new HashMap<>();
 
     bindings.put("files", contentMap);
@@ -174,27 +188,28 @@ public class KubernetesV2Utils {
   }
 
   @Data
-  public static class SecretSpec {
+  public static class ResourceSpec {
     TemplatedResource resource;
     String name;
+    ConfigSource.Type type;
   }
 
   @Data
-  public static class SecretMountPair {
+  public static class ResourceMountPair {
     File contents;
     byte[] contentBytes;
     String name;
 
-    public SecretMountPair(File inputFile) {
+    public ResourceMountPair(File inputFile) {
       this(inputFile, inputFile);
     }
 
-    public SecretMountPair(File inputFile, File outputFile) {
+    public ResourceMountPair(File inputFile, File outputFile) {
       this.contents = inputFile;
       this.name = outputFile.getName();
     }
 
-    public SecretMountPair(String name, byte[] contentBytes) {
+    public ResourceMountPair(String name, byte[] contentBytes) {
       this.contentBytes = contentBytes;
       this.name = name;
     }

--- a/halyard-deploy/src/main/resources/kubernetes/manifests/configMap.yml
+++ b/halyard-deploy/src/main/resources/kubernetes/manifests/configMap.yml
@@ -1,0 +1,17 @@
+{
+  "apiVersion": "v1",
+  "kind": "ConfigMap",
+  "metadata": {
+    "name": "{{ name }}",
+    "namespace": "{{ namespace }}",
+    "labels": {
+      "app": "spin",
+      "cluster": "spin-{{ clusterName }}"
+    }
+  },
+  "data": {
+    {% for file, contents in files.items() %}
+    "{{ file }}": "{{ contents }}" {% if not loop.last %} , {% endif %}
+    {% endfor %}
+  }
+}

--- a/halyard-deploy/src/test/groovy/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2UtilsTest.groovy
+++ b/halyard-deploy/src/test/groovy/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2UtilsTest.groovy
@@ -1,0 +1,80 @@
+package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.kubernetes.v2
+
+import com.netflix.spinnaker.halyard.config.services.v1.FileService
+import com.netflix.spinnaker.halyard.core.secrets.v1.SecretSessionManager
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ConfigSource
+import com.netflix.spinnaker.kork.configserver.CloudConfigResourceService
+import spock.lang.Specification
+
+class KubernetesV2UtilsTest extends Specification {
+
+    private SecretSessionManager mockSecretSessionManager
+    private CloudConfigResourceService mockCloudConfigResourceService
+    private FileService mockFileService
+
+    def setup() {
+        mockSecretSessionManager = Stub(SecretSessionManager)
+        mockCloudConfigResourceService = Stub(CloudConfigResourceService)
+        mockFileService = Stub(FileService)
+    }
+
+    def "should return config file as Config Map"() {
+        setup:
+        String testNamespace = UUID.randomUUID().toString()
+        String testClusterName = UUID.randomUUID().toString()
+        String testName = UUID.randomUUID().toString()
+        String testFileName = UUID.randomUUID().toString()
+        byte[] testFileContent = UUID.randomUUID().toString().getBytes()
+        KubernetesV2Utils.ResourceMountPair testFile = new KubernetesV2Utils.ResourceMountPair(testFileName, testFileContent)
+        List<KubernetesV2Utils.ResourceMountPair> testFiles = Arrays.asList(testFile)
+
+        KubernetesV2Utils kubernetesV2Utils = new KubernetesV2Utils(
+                ConfigSource.Type.configMap,
+                mockSecretSessionManager,
+                mockCloudConfigResourceService,
+                mockFileService
+        )
+
+        when:
+        KubernetesV2Utils.ResourceSpec resourceSpec = kubernetesV2Utils.createResourceSpec(
+                testNamespace,
+                testClusterName,
+                testName,
+                testFiles
+        )
+
+        then:
+        resourceSpec.type == ConfigSource.Type.configMap
+        resourceSpec.resource.toString().contains("\"kind\": \"ConfigMap\"")
+    }
+
+    def "should return config file as Secret"() {
+        setup:
+        String testNamespace = UUID.randomUUID().toString()
+        String testClusterName = UUID.randomUUID().toString()
+        String testName = UUID.randomUUID().toString()
+        String testFileName = UUID.randomUUID().toString()
+        byte[] testFileContent = UUID.randomUUID().toString().getBytes()
+        KubernetesV2Utils.ResourceMountPair testFile = new KubernetesV2Utils.ResourceMountPair(testFileName, testFileContent)
+        List<KubernetesV2Utils.ResourceMountPair> testFiles = Arrays.asList(testFile)
+
+        KubernetesV2Utils kubernetesV2Utils = new KubernetesV2Utils(
+                ConfigSource.Type.secret,
+                mockSecretSessionManager,
+                mockCloudConfigResourceService,
+                mockFileService
+        )
+
+        when:
+        KubernetesV2Utils.ResourceSpec resourceSpec = kubernetesV2Utils.createResourceSpec(
+                testNamespace,
+                testClusterName,
+                testName,
+                testFiles
+        )
+
+        then:
+        resourceSpec.type == ConfigSource.Type.secret
+        resourceSpec.resource.toString().contains("\"kind\": \"Secret\"")
+    }
+}


### PR DESCRIPTION
**Usage**

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: halyard-config-map
data:
  config: |
    halyard:
      configSourceType: secret # or configMap
```

**References:**

* https://armory.atlassian.net/browse/SPLAT-404